### PR TITLE
Scrolling on the widget doesn't change sound with amixer 1.0.24.2

### DIFF
--- a/volume.lua
+++ b/volume.lua
@@ -398,10 +398,10 @@ local function set_master_control(v_graph)
       set_master("toggle")
     end),
     awful.button({ }, 5, function()
-      set_master("2-")
+      set_master("2%-")
     end),
     awful.button({ }, 4, function()
-      set_master("2+")
+      set_master("2%+")
     end)))
 end
 


### PR DESCRIPTION
I found out that it absolute numbers feeded to amixer do nothing. I simply added percentage signs to the numbers and everything is OK now.
