### PR TITLE
fixed typo

### DIFF
--- a/system.lua
+++ b/system.lua
@@ -111,7 +111,7 @@ end
 --@param accept_image an image file for the accept menu entry
 --@param cancel_image an image file for the cancel menu entry
 function system.rebootmenu(button_image, accept_image, cancel_image)
-  if not buttom_image then
+  if not button_image then
 		button_image = superproperties.reboot or nil
 	end
 	if not accept_image then


### PR DESCRIPTION
reboot menu wasn't visible, because of the misspelled argument name
