### PR TITLE
Optional automount

### DIFF
--- a/.udisks-glue.conf
+++ b/.udisks-glue.conf
@@ -16,6 +16,15 @@ match disks {
            post_removal_command = "echo \'udisks_glue:remove_device(\"%device_file\",\"%mount_point\",\"Usb\")\' | awesome-client"
        }
 
+# Use this instead if you want to disable automount on disks.
+#match disks {
+#	automount = false
+#	automount_options = sync
+#	post_insertion_command = "echo \'udisks_glue:insert_device(\"%device_file\",\"%mount_point\",\"Usb\")\' | awesome-client"
+#	post_mount_command = "echo \'udisks_glue:mount_device(\"%device_file\",\"%mount_point\",\"Usb\")\' | awesome-client"
+#	post_unmount_command = "echo \'udisks_glue:unmount_device(\"%device_file\",\"%mount_point\",\"Usb\")\' | awesome-client"
+#	post_removal_command = "echo \'udisks_glue:remove_device(\"%device_file\",\"%mount_point\",\"Usb\")\' | awesome-client"
+#}
 
 match optical {
           automount = true
@@ -24,3 +33,13 @@ match optical {
           post_unmount_command = "echo \'udisks_glue:unmount_device(\"%device_file\",\"%mount_point\",\"Cdrom\")\' | awesome-client"
           post_removal_command = "echo \'udisks_glue:remove_device(\"%device_file\",\"%mount_point\",\"Cdrom\")\' | awesome-client"
 }
+
+# Use this instead if you want to disable automount of optical devices.
+#match optical {
+#	automount = false
+#	automount_options = ro
+#	post_insertion_command = "echo \'udisks_glue:insert_device(\"%device_file\",\"%mount_point\",\"Cdrom\")\' | awesome-client"
+#	post_mount_command = "echo \'udisks_glue:mount_device(\"%device_file\",\"%mount_point\",\"Cdrom\")\' | awesome-client"
+#	post_unmount_command = "echo \'udisks_glue:unmount_device(\"%device_file\",\"%mount_point\",\"Cdrom\")\' | awesome-client"
+#	post_removal_command = "echo \'udisks_glue:remove_device(\"%device_file\",\"%mount_point\",\"Cdrom\")\' | awesome-client"
+#}

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Create a menu which displays mounted media with actions like mount/unmount/detac
     udisks_glue=blingbling.udisks_glue.new({ menu_icon = themes_dir .. "/test/titlebar/maximized_focus_active.png"})
 
 note: udisks-glue have not been updated since one or 2 years. Furthermore it doesn't work with logind which is used in a lot of distributions. So I think that I have to find another way to manage external media.
+note: Added minor update to allow udisks_glue to insert a device without mounting it. See .udisks_glue.conf
 
 #####system
 Provide buttons with menu in order to reboot or shutdown the system. User can set icon for menu, accept and cancel actions.


### PR DESCRIPTION
This change makes automount optional by adding a udisks_glue.insert_device function that will add the device to the menu, but set it's status to be unmounted. If .udisks-glue.conf sets automount to false and uses post_insertion_command then removable devices won't be automounted.
