### PR TITLE
Improved alignment of the "ps" popup table

### DIFF
--- a/popups.lua
+++ b/popups.lua
@@ -35,11 +35,10 @@ end
 --@author LiamMayfair
 local function align_table(table_string)
     -- Provide sufficient spacing between row fields.
-    --local rows = split(table_string, "\n") -- Use helpers.split() instead.
     local rows = helpers.split(table_string, "\n")
     local aligned_table_rows = {}
     -- Align table header.
-    local header_fields = split(rows[1])
+    local header_fields = helpers.split(rows[1])
     local aligned_header_fields = header_fields[1]
     for hi=2,#header_fields do
 	aligned_header_fields = aligned_header_fields .. "\t" .. header_fields[hi] .. "   "
@@ -49,7 +48,7 @@ local function align_table(table_string)
     table.remove(table_body_rows, 1)
     local aligned_body_rows = {}
     for i,v in ipairs(table_body_rows) do
-	local row_fields = split(v)
+	local row_fields = helpers.split(v)
 	local aligned_row = ""
 	for fi, fv in ipairs(row_fields) do
 	   -- Certain fields are so short they cause misalignments in the table.


### PR DESCRIPTION
Push comment:

"Add and implement functions "pad_cell" and "align_table" to provide better alignment of the "ps" command popup table."

Now all the columns of the table 'ps' outputs, which gets displayed via a Naughty notification, have much better alignment and a cleaner look.

![popup-1366x768](https://cloud.githubusercontent.com/assets/9487006/5323094/948bdb28-7cc4-11e4-9f07-1a77fe871dce.png)
