### PR TITLE
add string format for text values

### DIFF
--- a/line_graph.lua
+++ b/line_graph.lua
@@ -262,7 +262,7 @@ function linegraph.draw(graph, wibox, cr, width, height)
         cr:select_font_face(font.family or "Sans", font.slang or "normal", font.weight or "normal")
       end
     
-      local value = data[graph].values[1] * 100
+      local value = string.format("%2.f", data[graph].values[1] * 100)
       if data[graph].label then
         text=string.gsub(data[graph].label,"$percent", value)
       else

--- a/line_graph.lua
+++ b/line_graph.lua
@@ -66,6 +66,13 @@ local data = setmetatable({}, { __mode = "k" })
 --@class function
 --@param boolean true or false (default is false)
 
+---Define displayed text value format string
+--@usage mygraph:set_value_format(string) --> "%2.f"
+--@name set_value_format
+--@class function
+--@param graph the graph
+--@param printf format string for display text
+
 ---Define the color of the text.
 --@usage mygraph:set_text_color(string) -->"#rrggbbaa"
 --@name set_text_color
@@ -106,7 +113,7 @@ local properties = {    "width", "height", "h_margin", "v_margin",
                         "graph_background_border", "graph_background_color",
                         "rounded_size", "graph_color", "graph_line_color",
                         "show_text", "text_color", "font_size", "font",
-                        "text_background_color", "label"
+                        "text_background_color", "label", "value_format"
                    }
 
 function linegraph.draw(graph, wibox, cr, width, height)
@@ -116,6 +123,7 @@ function linegraph.draw(graph, wibox, cr, width, height)
 
     -- Set the values we need
     local value = data[graph].value
+
     
     local graph_border_width = 0
     if data[graph].graph_background_border then
@@ -142,6 +150,7 @@ function linegraph.draw(graph, wibox, cr, width, height)
     local text_background_color = data[graph].text_background_color or superproperties.text_background_color
     local font_size =data[graph].font_size or superproperties.font_size
     local font = data[graph].font or superproperties.font
+    local value_format = data[graph].value_format or superproperties.value_format
     
     local line_width = 1
     cr:set_line_width(line_width)
@@ -262,7 +271,7 @@ function linegraph.draw(graph, wibox, cr, width, height)
         cr:select_font_face(font.family or "Sans", font.slang or "normal", font.weight or "normal")
       end
     
-      local value = string.format("%2.f", data[graph].values[1] * 100)
+      local value = string.format(value_format, data[graph].values[1] * 100)
       if data[graph].label then
         text=string.gsub(data[graph].label,"$percent", value)
       else

--- a/progress_graph.lua
+++ b/progress_graph.lua
@@ -68,6 +68,13 @@ local progressgraph = { mt = {} }
 --@param graph the graph
 --@param boolean true or false (default is false)
 
+---Define displayed text value format string
+--@usage mygraph:set_value_format(string) --> "%2.f"
+--@name set_value_format
+--@class function
+--@param graph the graph
+--@param printf format string for display text
+
 ---Define the color of the text.
 --@usage mygraph:set_text_color(string) -->"#rrggbbaa"
 --@name set_text_color
@@ -113,13 +120,15 @@ local properties = {    "width", "height", "v_margin", "h_margin",
                         "background_color",
                         "graph_background_color","rounded_size",
                         "graph_color", "graph_line_color","show_text", "text_color", 
-                        "text_background_color" ,"label", "font_size","font","horizontal"}
+                        "text_background_color" ,"label", "font_size","font","horizontal",
+                        "value_format"}
 
 function progressgraph.draw(p_graph, wibox, cr, width, height)
     -- We want one pixel wide lines
     cr:set_line_width(1)
     -- Set the values we need
     local value = data[p_graph].value
+    local value_format = data[value_format] or superproperties.value_format
     
     local v_margin =  superproperties.v_margin 
     if data[p_graph].v_margin and data[p_graph].v_margin <= data[p_graph].height/4 then 
@@ -187,7 +196,7 @@ function progressgraph.draw(p_graph, wibox, cr, width, height)
           cr:select_font_face(font.family or "Sans", font.slang or "normal", font.weight or "normal")
         end
         
-        local value = string.format("%2.f", data[p_graph].value * 100)
+        local value = string.format(value_format, data[p_graph].value * 100)
         if data[p_graph].label then
             text=string.gsub(data[p_graph].label,"$percent", value)
         else

--- a/progress_graph.lua
+++ b/progress_graph.lua
@@ -187,7 +187,7 @@ function progressgraph.draw(p_graph, wibox, cr, width, height)
           cr:select_font_face(font.family or "Sans", font.slang or "normal", font.weight or "normal")
         end
         
-        local value = data[p_graph].value * 100
+        local value = string.format("%2.f", data[p_graph].value * 100)
         if data[p_graph].label then
             text=string.gsub(data[p_graph].label,"$percent", value)
         else

--- a/superproperties.lua
+++ b/superproperties.lua
@@ -32,6 +32,7 @@ return {
   text_color= blingbling_theme.text_color or "#ffffff" ;
   font_size= blingbling_theme.font_size or 9 ;
   font = blingbling_theme.font or "sans";
+  value_format = blingbling_theme.value_format or "%2.f";
   text_background_color = blingbling_theme.text_background_color or "#00000066" ;
   background_text_border = blingbling_theme.background_text_border or "#ffffff";
 --theme values for popups module:


### PR DESCRIPTION
Lua's 5.3 release adds integers and caused some other notable changes
around the behaviour of floats being cast to strings [1]. This causes
certain widgets to report "silly" values for certain resources like 33.0%
RAM usage instead of just 33%.

Note, this is likely not the best way to fix this problem. A better
solution may be to have the user specify a `text_format` property and
default, maybe, to `%2.f` if nothing is provided. However, I'm going for the 
lazy approach for now. This also may be applicable for other widgets.

[1]: http://www.lua.org/manual/5.3/manual.html#