### PR TITLE
Pulse audio support for volume widget

### DIFF
--- a/volume.lua
+++ b/volume.lua
@@ -53,10 +53,13 @@ local function get_master_infos(volume_graph)
       end
       f:close()
    end
-   if (state == "yes" or state == "off") then
+   if (not state or state == "yes" or state == "off") then
       state = true  -- output is mute
    else
       state = false
+   end
+   if (not volume) then
+      volume = 0
    end
    return state, volume
 end

--- a/volume.lua
+++ b/volume.lua
@@ -162,7 +162,6 @@ function volume.new(args)
     data[volume_graph].cmd = args.cmd or "amixer"
     data[volume_graph].increment = args.increment or 2
     data[volume_graph].pulseaudio = args.pulseaudio or false
-    data[volume_graph].mute_color = "#550000"
     volume_graph.update_master = update_master
     volume_graph.update_mpd= update_mpd
     volume_graph.set_master_control = set_master_control


### PR DESCRIPTION
Hi,
I use pulseaudio and using amixer though the volume widget resulted in instability and even a big freeze of awesome.
I've added pulseaudio support for controls and volume/state retrieval, using a simple shell front-end to pactl:  https://github.com/graysky2/pulseaudio-ctl which proved much simpler to use.

Removing the dependency and using pactl directly is possible but would require more work to parse the output to retrieve volume/state correctly.

I've also added an 'increment' parameter to let the user choose the volume increment/decrement value on mouse wheel events.

I hope it would be useful to others and I'll be happy to modify it if necessary.